### PR TITLE
Support running N flows, where each flow does not have to use the same congestion control scheme

### DIFF
--- a/test/parse_arguments.py
+++ b/test/parse_arguments.py
@@ -163,12 +163,11 @@ def verify_test_args(args):
                      'fit in runtime')
 
 def parse_test_config(test_config, local, remote):
-
     # Check config file has atleast a test-name and a description of flows
     if 'test-name' not in test_config:
-        raise ValueError('Config file must have a test-name argument')
+        sys.exit('Config file must have a test-name argument')
     if 'flows' not in test_config:
-        raise ValueError('Config file must specify flows')
+        sys.exit('Config file must specify flows')
     
     defaults = {}
     defaults.update(**test_config)
@@ -221,6 +220,10 @@ def parse_test():
     args = parser.parse_args(remaining_argv)
     if args.schemes is not None:
         verify_schemes(args.schemes)
+    else:
+        assert(test_config is not None)
+        schemes = ' '.join([flow['scheme'] for flow in test_config['flows']])
+        verify_schemes(schemes)
     verify_test_args(args)
     make_sure_path_exists(args.data_dir)
     return args

--- a/test/parse_arguments.py
+++ b/test/parse_arguments.py
@@ -163,12 +163,20 @@ def verify_test_args(args):
                      'fit in runtime')
 
 def parse_test_config(test_config, local, remote):
+
+    # Check config file has atleast a test-name and a description of flows
+    if 'test-name' not in test_config:
+        raise ValueError('Config file must have a test-name argument')
+    if 'flows' not in test_config:
+        raise ValueError('Config file must specify flows')
+    
     defaults = {}
     defaults.update(**test_config)
     defaults['schemes'] = None
     defaults['all'] = False
     defaults['flows'] = len(test_config['flows'])
     defaults['test_config'] = test_config
+
     local.set_defaults(**defaults)
     remote.set_defaults(**defaults)
     

--- a/test/test.py
+++ b/test/test.py
@@ -801,7 +801,6 @@ def pkill(args):
 
 def main():
     args = parse_arguments(path.basename(__file__))
-    print(args)
     try:
         run_tests(args)
     except:  # intended to catch all exceptions

--- a/test/tests/local_test.py
+++ b/test/tests/local_test.py
@@ -4,6 +4,35 @@ from os import path
 import project_root
 from helpers.helpers import check_call
 
+def get_sample_config(config_name):
+    if config_name == 'bbr-cubic':
+        config = ('test-name: test-bbr \n'
+                  'runtime: 30 \n'
+                  'interval: 1 \n'
+                  'random_order: true \n'
+                  'extra_mm_link_args: --uplink-queue=droptail '
+                  '--uplink-queue-args=packets=512 \n'
+                  'prepend_mm_cmds: mm-delay 30 \n'
+                  'flows: \n'
+                  '  - scheme: bbr \n'
+                  '  - scheme: default_tcp # cubic ')
+
+    elif config_name == 'verus-cubic':
+        config = ('test-name: test-bbr \n'
+                  'runtime: 30 \n'
+                  'interval: 1 \n'
+                  'random_order: true \n'
+                  'extra_mm_link_args: --uplink-queue=droptail '
+                  '--uplink-queue-args=packets=512 \n'
+                  'prepend_mm_cmds: mm-delay 30 \n'
+                  'flows: \n'
+                  '  - scheme: verus \n'
+                  '  - scheme: default_tcp # cubic ')
+               
+    with open('/tmp/pantheon-tmp/{}.yml'.format(config_name), 'w') as f:
+        f.write(config)
+        
+    return '/tmp/pantheon-tmp/{}.yml'.format(config_name)
 
 def main():
     curr_dir = path.dirname(path.abspath(__file__))
@@ -12,6 +41,7 @@ def main():
 
     test_py = path.join(project_root.DIR, 'test', 'test.py')
 
+    """
     # test a receiver-first scheme --- default_tcp
     cc = 'default_tcp'
 
@@ -58,7 +88,22 @@ def main():
            '--uplink-trace', data_trace, '--downlink-trace', ack_trace,
            '--pkill-cleanup', '--schemes', '%s' % cc]
     check_call(cmd)
+    """
 
+    # test running with a config file -- two reciever first schemes
+    config = get_sample_config('bbr-cubic')
+    cmd = ['python', test_py, '-c', config, 'local',
+           '--uplink-trace', data_trace, '--downlink-trace', ack_trace,
+           '--pkill-cleanup']
+    check_call(cmd)
+    
+    # test running with a config file -- one receiver first, one sender first scheme
+    config = get_sample_config('verus-cubic')
+    cmd = ['python', test_py, '-c', config, 'local',
+           '--uplink-trace', data_trace, '--downlink-trace', ack_trace,
+           '--pkill-cleanup']
+    check_call(cmd)
+    
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
These changes allow users to run N flows, each using any congestion control scheme by specifying the schemes for each flow in a YAML file. 

New usage with optional `-c`, `--config_file` flags:
```
usage: test.py [-h] [-c CONFIG] {local,remote} ...

perform congestion control tests

positional arguments:
  {local,remote}
    local               test schemes locally in mahimahi emulated networks
    remote              test schemes between local and remote in real-life networks

optional arguments:
  -h, --help            show this help message and exit
  -c CONFIG, --config_file CONFIG
                        path to configuration file. command line arguments will
                        override options in config file.
```


The minimal YAML config file:
```yaml
# Describe one test. Test must have a name and describe what scheme each flow should use.
test-name: bbr-cubic 
```

Another example YAML config file:
```yaml
test-name: bbr-cubic 
runtime: 30
interval: 1
random_order: true
extra_mm_link_args: --uplink-queue=droptail --uplink-queue-args=packets=512
prepend_mm_cmds: mm-delay 30
flows:
  - scheme: bbr
  - scheme: default_tcp
```

Users can run using a config file and pass command line arguments, overriding any args specified in the config file:
```
 python test.py -c ~/pantheon_sample_config.yml local --run-times 2 --interval 2
```

The main goal was to make as minimal of changes as possible and be backwards compatible with the previous way of supplying input via command line args.

**Testing**
- I've added tests with config files to `local_test.py`
- I did not do any remote testing

**Config file features & design decisions**
- Users can still run tests the old way without specifying a config file.
- Arguments specified in a config file can be overridden by passing command line args.
- Config files must at least specify (1) a test-name (which replaces 'cc' arg in Test objects) and (2) some flows. 
- When the `-c, --config` flag is present you can still specify all of the command line arguments for the local or remote tests with the exception of `-f, --flows`, `--all`, and `--schemes` since users should specify what schemes they want to test with the config file.
- Users cannot use a config file AND run tests the old way. Config file must specify flows. The desired behavior could be to specify flows the old way and if there are no flows described in the config file. Ex: Users cannot do this: `./test.py -c config.yml -f 2 --all`. This would have made arg parsing and changes to `test.py` more convoluted so I did not try to support that kind of input.
- Config file keys are not verified for valid arguments. If a user specifies an invalid argument in a config file like `abc: xyz` it is just ignored. 
- Keyword arguments in config file must correspond to the internal variable in `args` rather than the command line name of that argument. Ex: On the command line you use `--run-times` flag, in the config file file you use `run_times` key. Changing this behavior would have complicated the ability to override config args via the command line so I did not try to, but it could be done if need be.
- Users can only run one test when you use a config file. Users can run the same test multiple times using the `--run-times` flag or keyword argument. A desired feature could be the ability to run multiple tests by specifying more than one in the config file.
- Config file command line argument assumes absolute path to config file. Desired behavior could be to assume config file is within pantheon dir.

**Enabling running multiple schemes**
- Created 'Flow' objects to store data about the each flow's scheme, which command needs to run first, and paths to scheme src file. Flow objects replace 'cc' & 'cc_src' in the old code when running with a config. Flow objects are not used when running without a config.
- Many of the changes to `test.py` were implemented by simply adding `if` statements that only get executed and evaluate to true if the test is run with a config file.

**Other possible issues**
- The qdisc for a test with BBR is not changed to 'fq' when running with a config file. This could be changed by checking if any of the `cc_schemes` are BBR and then setting the qdisc to 'fq' if that's the desired behavior.

I probably left out some details, but I'd be happy to walk through the changes over Hangouts.